### PR TITLE
monero v1 PoW changes

### DIFF
--- a/src/crypto/CryptoNight.cpp
+++ b/src/crypto/CryptoNight.cpp
@@ -30,31 +30,31 @@
 #include "Options.h"
 
 
-void (*cryptonight_hash_ctx)(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = nullptr;
+bool (*cryptonight_hash_ctx)(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) = nullptr;
 
 
-static void cryptonight_av1_aesni(const void *input, size_t size, void *output, struct cryptonight_ctx *ctx) {
-    cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, false>(input, size, output, ctx);
+static bool cryptonight_av1_aesni(const void *input, size_t size, void *output, struct cryptonight_ctx *ctx, int variant) {
+    return cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, false, true>(input, size, output, ctx, variant);
 }
 
 
-static void cryptonight_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, true>(input, size, output, ctx);
+static bool cryptonight_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) {
+    return cryptonight_hash<0x80000, MEMORY, 0x1FFFF0, true, true>(input, size, output, ctx, variant);
 }
 
 
 #ifndef XMRIG_NO_AEON
-static void cryptonight_lite_av1_aesni(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, false>(input, size, output, ctx);
+static bool cryptonight_lite_av1_aesni(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) {
+    return cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, false, false>(input, size, output, ctx, variant);
 }
 
 
-static void cryptonight_lite_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx) {
-    cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, true>(input, size, output, ctx);
+static bool cryptonight_lite_av3_softaes(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) {
+    return cryptonight_hash<0x40000, MEMORY_LITE, 0xFFFF0, true, false>(input, size, output, ctx, variant);
 }
 
 
-void (*cryptonight_variations[8])(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = {
+bool (*cryptonight_variations[8])(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) = {
             cryptonight_av1_aesni,
             nullptr,
             cryptonight_av3_softaes,
@@ -65,7 +65,7 @@ void (*cryptonight_variations[8])(const void *input, size_t size, void *output, 
             nullptr
         };
 #else
-void (*cryptonight_variations[4])(const void *input, size_t size, void *output, cryptonight_ctx *ctx) = {
+bool (*cryptonight_variations[4])(const void *input, size_t size, void *output, cryptonight_ctx *ctx, int variant) = {
             cryptonight_av1_aesni,
             nullptr,
             cryptonight_av3_softaes,
@@ -76,9 +76,13 @@ void (*cryptonight_variations[4])(const void *input, size_t size, void *output, 
 
 bool CryptoNight::hash(const Job &job, JobResult &result, cryptonight_ctx *ctx)
 {
-    cryptonight_hash_ctx(job.blob(), job.size(), result.result, ctx);
-
-    return *reinterpret_cast<uint64_t*>(result.result + 24) < job.target();
+    bool success = false;
+    if (1 < job.size())
+    {
+        const int variant = ((const uint8_t*)job.blob())[0] >= 7 ? ((const uint8_t*)job.blob())[0] - 6 : 0;
+        success = cryptonight_hash_ctx(job.blob(), job.size(), result.result, ctx, variant);
+    }
+    return success && *reinterpret_cast<uint64_t*>(result.result + 24) < job.target();
 }
 
 
@@ -100,9 +104,9 @@ bool CryptoNight::init(int algo, int variant)
 }
 
 
-void CryptoNight::hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx)
+bool CryptoNight::hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx, int variant)
 {
-    cryptonight_hash_ctx(input, size, output, ctx);
+    return cryptonight_hash_ctx(input, size, output, ctx, variant);
 }
 
 
@@ -115,13 +119,13 @@ bool CryptoNight::selfTest(int algo) {
 
     cryptonight_ctx *ctx = static_cast<cryptonight_ctx*>(_mm_malloc(sizeof(struct cryptonight_ctx), 16));
 
-    cryptonight_hash_ctx(test_input, 76, output, ctx);
+    const bool success = cryptonight_hash_ctx(test_input, 76, output, ctx, 0);
 
     _mm_free(ctx);
 
 #   ifdef XMRIG_NO_AEON
-    return memcmp(output, test_output0, 32) == 0;
+    return successs && memcmp(output, test_output0, 32) == 0;
 #   else
-    return memcmp(output, algo == Options::ALGO_CRYPTONIGHT_LITE ? test_output1 : test_output0, 32) == 0;
+    return success && memcmp(output, algo == Options::ALGO_CRYPTONIGHT_LITE ? test_output1 : test_output0, 32) == 0;
 #   endif
 }

--- a/src/crypto/CryptoNight.h
+++ b/src/crypto/CryptoNight.h
@@ -53,7 +53,7 @@ class CryptoNight
 public:
     static bool hash(const Job &job, JobResult &result, cryptonight_ctx *ctx);
     static bool init(int algo, int variant);
-    static void hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx);
+    static bool hash(const uint8_t *input, size_t size, uint8_t *output, cryptonight_ctx *ctx, int variant);
 
 private:
     static bool selfTest(int algo);

--- a/src/nvidia/cryptonight.h
+++ b/src/nvidia/cryptonight.h
@@ -28,6 +28,7 @@ typedef struct {
 	uint32_t *d_ctx_key1;
 	uint32_t *d_ctx_key2;
 	uint32_t *d_ctx_text;
+	uint32_t *d_tweak1_2;
 } nvid_ctx;
 
 extern "C" {
@@ -37,8 +38,8 @@ int cuda_get_runtime_version();
 int cuda_get_deviceinfo(nvid_ctx *ctx);
 int cryptonight_gpu_init(nvid_ctx *ctx);
 void cryptonight_extra_cpu_set_data( nvid_ctx* ctx, const void *data, uint32_t len);
-void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce);
-void cryptonight_gpu_hash(nvid_ctx* ctx);
+void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, int variant, uint32_t startNonce);
+void cryptonight_gpu_hash(nvid_ctx* ctx, int variant);
 void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t target, uint32_t* rescount, uint32_t *resnonce);
 
 #ifndef XMRIG_NO_AEON

--- a/src/nvidia/cuda_extra.cu
+++ b/src/nvidia/cuda_extra.cu
@@ -87,7 +87,7 @@ __device__ __forceinline__ void cryptonight_aes_set_key( uint32_t * __restrict__
 	}
 }
 
-__global__ void cryptonight_extra_gpu_prepare( int threads, uint32_t * __restrict__ d_input, uint32_t len, uint32_t startNonce, uint32_t * __restrict__ d_ctx_state, uint32_t * __restrict__ d_ctx_a, uint32_t * __restrict__ d_ctx_b, uint32_t * __restrict__ d_ctx_key1, uint32_t * __restrict__ d_ctx_key2 )
+__global__ void cryptonight_extra_gpu_prepare( int threads, uint32_t * __restrict__ d_input, uint32_t len, uint32_t startNonce, uint32_t * __restrict__ d_ctx_state, uint32_t * __restrict__ d_ctx_a, uint32_t * __restrict__ d_ctx_b, uint32_t * __restrict__ d_ctx_key1, uint32_t * __restrict__ d_ctx_key2, int variant, uint32_t * __restrict__ d_tweak1_2)
 {
 	int thread = ( blockDim.x * blockIdx.x + threadIdx.x );
 
@@ -100,6 +100,7 @@ __global__ void cryptonight_extra_gpu_prepare( int threads, uint32_t * __restric
 	uint32_t ctx_key1[40];
 	uint32_t ctx_key2[40];
 	uint32_t input[21];
+	uint32_t tweak1_2[2];
 
 	memcpy( input, d_input, len );
 	//*((uint32_t *)(((char *)input) + 39)) = startNonce + thread;
@@ -112,6 +113,15 @@ __global__ void cryptonight_extra_gpu_prepare( int threads, uint32_t * __restric
 	cryptonight_aes_set_key( ctx_key2, ctx_state + 8 );
 	XOR_BLOCKS_DST( ctx_state, ctx_state + 8, ctx_a );
 	XOR_BLOCKS_DST( ctx_state + 4, ctx_state + 12, ctx_b );
+
+	if (variant > 0)
+	{
+		tweak1_2[0] = (input[8] >> 24) | (input[9] << 8);
+		tweak1_2[0] ^= ctx_state[48];
+		tweak1_2[1] = (input[9] >> 24) | (input[10] << 8);
+		tweak1_2[1] ^= ctx_state[49];
+		memcpy( d_tweak1_2 + thread * 2, tweak1_2, 8 );
+	}
 
 	memcpy( d_ctx_state + thread * 50, ctx_state, 50 * 4 );
 	memcpy( d_ctx_a + thread * 4, ctx_a, 4 * 4 );
@@ -200,10 +210,11 @@ int cryptonight_extra_cpu_init(nvid_ctx* ctx)
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_input,        21  * sizeof(uint32_t)));
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_result_count, sizeof(uint32_t)));
     CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_result_nonce, 10  * sizeof(uint32_t)));
+    CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_tweak1_2, 2 * sizeof(uint32_t) * wsize));
 	return 1;
 }
 
-extern "C" void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce)
+extern "C" void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, int variant, uint32_t startNonce)
 {
 	int threadsperblock = 128;
 	uint32_t wsize = ctx->device_blocks * ctx->device_threads;
@@ -212,7 +223,7 @@ extern "C" void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce
 	dim3 block( threadsperblock );
 
     CUDA_CHECK_KERNEL(ctx->device_id, cryptonight_extra_gpu_prepare<<< grid, block >>>(wsize, ctx->d_input, ctx->inputlen, startNonce,
-        ctx->d_ctx_state, ctx->d_ctx_a, ctx->d_ctx_b, ctx->d_ctx_key1, ctx->d_ctx_key2));
+        ctx->d_ctx_state, ctx->d_ctx_a, ctx->d_ctx_b, ctx->d_ctx_key1, ctx->d_ctx_key2, variant, ctx->d_tweak1_2));
 }
 
 extern "C" void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t target, uint32_t* rescount, uint32_t *resnonce)

--- a/src/workers/CudaWorker.cpp
+++ b/src/workers/CudaWorker.cpp
@@ -89,17 +89,18 @@ void CudaWorker::start()
         while (!Workers::isOutdated(m_sequence)) {
             uint32_t foundNonce[10];
             uint32_t foundCount;
+            const int variant = m_job.size() && ((const uint8_t*)m_job.blob())[0] >= 7 ? ((const uint8_t*)m_job.blob())[0] - 6 : 0;
 
-            cryptonight_extra_cpu_prepare(&m_ctx, m_nonce);
+            cryptonight_extra_cpu_prepare(&m_ctx, variant, m_nonce);
 
 #           ifdef XMRIG_NO_AEON
-            cryptonight_gpu_hash(&m_ctx);
+            cryptonight_gpu_hash(&m_ctx, variant);
 #           else
             if (m_lite) {
                 cryptonight_gpu_hash_lite(&m_ctx);
             }
             else {
-                cryptonight_gpu_hash(&m_ctx);
+                cryptonight_gpu_hash(&m_ctx, variant);
             }
 #           endif
 


### PR DESCRIPTION
Changes for the monero v1 PoW algorithm. Some implementation notes:
- Be aware the pull request is to the master and not dev branch
- A bool template argument was added so that the inner aeon loop has no branches
- A bool template argument was **not** added to the cuda version, but was added to the xmr-stak version. The only reason for this was that I updated xmr-stak second, and the change didn't occur to me at the time. See that repo for a PR, its simple enough to add.
- Since this is XMR specific, a version template argument might be better to remove any _potential_ branching (the second tweak might be cmoved, but probably not the first).
- The first "tweak" touches the scratchpad after the MMX transfer. I'm not sure which is better, because I think unpacking that register is going to be costly, although perhaps hitting the L1 again is slower. Didn't have time for that deep of analysis.