### PR TITLE
Bug Fix:  cuda memory leak

### DIFF
--- a/src/nvidia/cryptonight.h
+++ b/src/nvidia/cryptonight.h
@@ -71,3 +71,4 @@ void cryptonight_extra_cpu_set_data(nvid_ctx *ctx, const void *data, size_t len)
 void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce, xmrig::Algo algo);
 void cryptonight_gpu_hash(nvid_ctx *ctx, xmrig::Algo algo, xmrig::Variant variant, uint32_t startNonce);
 void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t target, uint32_t* rescount, uint32_t *resnonce, xmrig::Algo algo);
+void cryptonight_extra_cpu_free(nvid_ctx* ctx);

--- a/src/nvidia/cuda_extra.cu
+++ b/src/nvidia/cuda_extra.cu
@@ -388,6 +388,20 @@ void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t ta
     }
 }
 
+void cryptonight_extra_cpu_free(nvid_ctx* ctx)
+{
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_key1));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_key2));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_text));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_a));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_b));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_input));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_result_count));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_result_nonce));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_long_state));
+    CUDA_CHECK(ctx->device_id, cudaFree(ctx->d_ctx_state));
+}
+
 int cuda_get_devicecount()
 {
     int deviceCount = 0;

--- a/src/workers/CudaWorker.cpp
+++ b/src/workers/CudaWorker.cpp
@@ -105,6 +105,8 @@ void CudaWorker::start()
 
         consumeJob();
     }
+    
+    cryptonight_extra_cpu_free(&m_ctx);
 }
 
 


### PR DESCRIPTION
Running a mem check showed a memory leak from cudaMalloc not being freed.
```
cuda-memcheck --binary-patching no --leak-check full xmrig-nvidia.exe -o .. -u ..
```

Before fix 
```
========= LEAK SUMMARY: 1006959488 bytes leaked in 10 allocations
========= ERROR SUMMARY: 10 errors
```

After fix
```
========= LEAK SUMMARY: 0 bytes leaked in 0 allocations
========= ERROR SUMMARY: 0 errors
```

**Many Thanks!**

