### PR TITLE
CUDA Compile Warning Fix

### DIFF
--- a/src/nvidia/cuda_extra.cu
+++ b/src/nvidia/cuda_extra.cu
@@ -29,7 +29,7 @@
 #include <string.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <device_functions.h>
+#include <cuda_runtime_api.h>
 
 #ifdef __CUDACC__
 __constant__


### PR DESCRIPTION
Compiling with `#include <device_functions.h>` throws a bunch of warnings:

```
[  2%] Building NVCC (Device) object CMakeFiles/xmrig-cuda.dir/src/nvidia/xmrig-cuda_generated_cuda_core.cu.o
[  4%] Building NVCC (Device) object CMakeFiles/xmrig-cuda.dir/src/nvidia/xmrig-cuda_generated_cuda_extra.cu.o
In file included from /home/ku4eto/Desktop/xmrig-nvidia/src/nvidia/cuda_extra.cu:32:0:
/usr/local/cuda-10.0/include/device_functions.h:54:2: warning: #warning "device_functions.h is an internal header file and must not be used directly.  This file will be removed in a future CUDA release.  Please use cuda_runtime_api.h or cuda_runtime.h instead." [-Wcpp]
 #warning "device_functions.h is an internal header file and must not be used directly.  This file will be removed in a future CUDA release.  Please use cuda_runtime_api.h or cuda_runtime.h instead."
  ^~~~~~~
```
After using `cuda_runtime_api.h`, the issue is fixed.
