### PR TITLE
Fix compatibility for MacOS

### DIFF
--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -135,9 +135,14 @@ set(CUDA_SOURCES
     src/nvidia/cuda_skein.hpp
 )
 
+# add c++11 for cuda
+if(NOT CMAKE_CXX_FLAGS MATCHES "-std=c\\+\\+11")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
+endif()
+
 if("${CUDA_COMPILER}" STREQUAL "clang")
     add_library(xmrig-cuda STATIC ${CUDA_SOURCES})
-    
+
     set_target_properties(xmrig-cuda PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
     set_target_properties(xmrig-cuda PROPERTIES LINKER_LANGUAGE CXX)
     set_source_files_properties(${CUDA_SOURCES} PROPERTIES LANGUAGE CXX)

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -40,7 +40,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES Clang)
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes -Wall")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes -Wall -fno-exceptions -fno-rtti")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes -Wall -fno-rtti")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 endif()


### PR DESCRIPTION
That makes xmrig-nvidia compile and work on MacOS. It was crashing on syntax error, so I added c+11 flag and removed pointless clang flags.

```
~/Documents/Projects/Smth/Code/deps/xmrig-nvidia/build  cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DBUILD_STATIC=Off -DCUDA_TOOLKIT_ROOT_DIR=/Developer/NVIDIA/CUDA-10.0 -DCUDA_NVRTC_LIB=/Developer/NVIDIA/CUDA-10.0/lib/libnvrtc.dylib -DCUDA_ARCH=61 ..  
-- The C compiler identification is AppleClang 9.1.0.9020039
-- The CXX compiler identification is AppleClang 9.1.0.9020039
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found UV: /usr/local/lib/libuv.a  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE  
-- Found CUDA: /Developer/NVIDIA/CUDA-10.0 (found suitable version "10.0", minimum required is "7.5") 
-- Could NOT find NVML (missing: NVML_INCLUDE_DIR) 
-- Found OpenSSL: /usr/local/opt/openssl/lib/libcrypto.dylib (found version "1.0.2q")  
-- The ASM compiler identification is AppleClang
-- Found assembler: /Library/Developer/CommandLineTools/usr/bin/cc
-- Looking for syslog.h
-- Looking for syslog.h - found
-- Found MHD: /usr/local/lib/libmicrohttpd.dylib  
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/build
 ~/Documents/Projects/Smth/Code/deps/xmrig-nvidia/build  make                                                                                                        master v2.13.0 ● ?
[  1%] Building NVCC (Device) object CMakeFiles/xmrig-cuda.dir/src/nvidia/xmrig-cuda_generated_cuda_extra.cu.o
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:281:49: warning: unused function 'cn_aes_single_round' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_single_round(uint32_t *__restrict__ sharedMemory, const uint32_t *__restrict__ in, uint32_t *__restrict__ out, const uint32_t *__restrict__ expandedKey) 
                                                ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:286:49: warning: unused function 'cn_aes_pseudo_round_mut' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_pseudo_round_mut(const uint32_t *__restrict__ sharedMemory, uint32_t *__restrict__ val, const uint32_t *__restrict__ expandedKey) 
                                                ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:301:49: warning: unused function 'cn_aes_gpu_init' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_gpu_init(uint32_t *sharedMemory) 
                                                ^
3 warnings generated.
[  2%] Building NVCC (Device) object CMakeFiles/xmrig-cuda.dir/src/nvidia/xmrig-cuda_generated_cuda_core.cu.o
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/common/utils/timestamp.h(41): warning: statement is unreachable

/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/common/utils/timestamp.h(41): warning: statement is unreachable

/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/common/utils/timestamp.h:34:23: warning: unused function 'steadyTimestamp' [-Wunused-function]
static inline int64_t steadyTimestamp() 
                      ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/common/utils/timestamp.h:45:23: warning: unused function 'currentMSecsSinceEpoch' [-Wunused-function]
static inline int64_t currentMSecsSinceEpoch() 
                      ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:281:49: warning: unused function 'cn_aes_single_round' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_single_round(uint32_t *__restrict__ sharedMemory, const uint32_t *__restrict__ in, uint32_t *__restrict__ out, const uint32_t *__restrict__ expandedKey) 
                                                ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:286:49: warning: unused function 'cn_aes_pseudo_round_mut' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_pseudo_round_mut(const uint32_t *__restrict__ sharedMemory, uint32_t *__restrict__ val, const uint32_t *__restrict__ expandedKey) 
                                                ^
/Users/andrey/Documents/Projects/Smth/Code/deps/xmrig-nvidia/src/nvidia/cuda_aes.hpp:301:49: warning: unused function 'cn_aes_gpu_init' [-Wunused-function]
__attribute((always_inline)) static inline void cn_aes_gpu_init(uint32_t *sharedMemory) 
                                                ^
5 warnings generated.
Scanning dependencies of target xmrig-cuda
[  4%] Linking CXX static library libxmrig-cuda.a
[  4%] Built target xmrig-cuda
Scanning dependencies of target xmrig-asm
[  5%] Building ASM object CMakeFiles/xmrig-asm.dir/src/crypto/asm/cn_main_loop.S.o
[  7%] Building ASM object CMakeFiles/xmrig-asm.dir/src/crypto/asm/CryptonightR_template.S.o
[  8%] Linking C static library libxmrig-asm.a
[  8%] Built target xmrig-asm
Scanning dependencies of target xmrig-nvidia
[ 10%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/api/NetworkState.cpp.o
[ 11%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/App.cpp.o
[ 12%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/io/Json.cpp.o
[ 14%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/io/Watcher.cpp.o
[ 15%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/kernel/Entry.cpp.o
[ 17%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/kernel/Process.cpp.o
[ 18%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/kernel/Signals.cpp.o
[ 20%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/net/Pool.cpp.o
[ 21%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/net/Pools.cpp.o
[ 22%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/tools/Arguments.cpp.o
[ 24%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/tools/Handle.cpp.o
[ 25%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/tools/String.cpp.o
[ 27%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/config/CommonConfig.cpp.o
[ 28%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/config/ConfigLoader.cpp.o
[ 30%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/config/ConfigWatcher.cpp.o
[ 31%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/Console.cpp.o
[ 32%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/cpu/BasicCpuInfo.cpp.o
[ 34%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/cpu/Cpu.cpp.o
[ 35%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/crypto/Algorithm.cpp.o
[ 37%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/crypto/keccak.cpp.o
[ 38%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/log/BasicLog.cpp.o
[ 40%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/log/ConsoleLog.cpp.o
[ 41%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/log/FileLog.cpp.o
[ 42%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/log/Log.cpp.o
[ 44%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/Client.cpp.o
[ 45%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/Job.cpp.o
[ 47%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/strategies/FailoverStrategy.cpp.o
[ 48%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/strategies/SinglePoolStrategy.cpp.o
[ 50%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/SubmitResult.cpp.o
[ 51%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/Platform.cpp.o
[ 52%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/core/Config.cpp.o
[ 54%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/core/Controller.cpp.o
[ 55%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/Mem.cpp.o
[ 57%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/net/Network.cpp.o
[ 58%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/net/strategies/DonateStrategy.cpp.o
[ 60%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/nvidia/CudaCLI.cpp.o
[ 61%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/nvidia/CudaCryptonightR_gen.cpp.o
[ 62%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/Summary.cpp.o
[ 64%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/workers/CudaWorker.cpp.o
[ 65%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/workers/CudaThread.cpp.o
[ 67%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/workers/Handle.cpp.o
[ 68%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/workers/Hashrate.cpp.o
[ 70%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/workers/Workers.cpp.o
[ 71%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/xmrig.cpp.o
[ 72%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/App_unix.cpp.o
[ 74%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/base/io/Json_unix.cpp.o
[ 75%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/Platform_mac.cpp.o
[ 77%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/Mem_unix.cpp.o
[ 78%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/nvidia/NvmlApi_stub.cpp.o
[ 80%] Building C object CMakeFiles/xmrig-nvidia.dir/src/crypto/c_groestl.c.o
[ 81%] Building C object CMakeFiles/xmrig-nvidia.dir/src/crypto/c_blake256.c.o
[ 82%] Building C object CMakeFiles/xmrig-nvidia.dir/src/crypto/c_jh.c.o
[ 84%] Building C object CMakeFiles/xmrig-nvidia.dir/src/crypto/c_skein.c.o
[ 85%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/crypto/CryptoNight.cpp.o
[ 87%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/crypto/CryptonightR_gen.cpp.o
[ 88%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/log/SysLog.cpp.o
[ 90%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/api/Api.cpp.o
[ 91%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/api/ApiRouter.cpp.o
[ 92%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/api/Httpd.cpp.o
[ 94%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/api/HttpRequest.cpp.o
[ 95%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/common/net/Tls.cpp.o
[ 97%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/crypto/cn_gpu_avx.cpp.o
[ 98%] Building CXX object CMakeFiles/xmrig-nvidia.dir/src/crypto/cn_gpu_ssse3.cpp.o
[100%] Linking CXX executable xmrig-nvidia
[100%] Built target xmrig-nvidia
 ~/Documents/Projects/HashToCash/Code/deps/xmrig-nvidia/build  ./xmrig-nvidia -o xmr.pool.hashto.cash:80 -u "31f2da90-b4e1-11e7-8c37-3ffdf979bc3d" -p "algo:cn/half" --print-time=5
 * ABOUT        XMRig-NVIDIA/2.13.0 clang/9.1.0
 * LIBS         libuv/1.25.0 CUDA/10.0 OpenSSL/1.0.2q microhttpd/0.9.62 
 * CPU          Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz x64 AES
 * GPU #0       PCI:0000:01:00 GeForce GTX 1080 Ti @ 1683/5505 MHz 44x84 0x0 arch:61 SMX:28
 * ALGO         cryptonight, donate=5%
 * POOL #1      xmr.pool.hashto.cash:80 variant auto
 * COMMANDS     hashrate, health, pause, resume
[2019-02-22 18:25:55] use pool xmr.pool.hashto.cash:80  195.201.169.235 
[2019-02-22 18:25:55] new job from xmr.pool.hashto.cash:80 diff 2500 algo cn/half
[2019-02-22 18:25:58] accepted (1/0) diff 2500 (66 ms)
[2019-02-22 18:25:59] Ctrl+C received, exiting
[2019-02-22 18:26:00] no active pools, stop mining

```