### PR TITLE
Fix CUDA8 crashing on 20; add true 21 support; add memory size display in Summary

### DIFF
--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -32,7 +32,7 @@ set(DEFAULT_CUDA_ARCH "30;50")
 
 # Fermi GPUs are only supported with CUDA < 9.0
 if (CUDA_VERSION VERSION_LESS 9.0)
-    list(APPEND DEFAULT_CUDA_ARCH "20")
+    list(APPEND DEFAULT_CUDA_ARCH "20 21")
 endif()
 
 # add Pascal support for CUDA >= 8.0
@@ -61,6 +61,7 @@ foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
                             "Use '20' (for compute architecture 2.0) or higher.")
     endif()
 endforeach()
+list(SORT CUDA_ARCH)
 
 option(CUDA_SHOW_REGISTER "Show registers used for each kernel and compute architecture" OFF)
 option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps" OFF)
@@ -89,11 +90,20 @@ elseif("${CUDA_COMPILER}" STREQUAL "nvcc")
     if (CUDA_VERSION VERSION_LESS 8.0)
         add_definitions(-D_FORCE_INLINES)
         add_definitions(-D_MWAITXINTRIN_H_INCLUDED)
+    elseif(CUDA_VERSION VERSION_LESS 9.0)
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Wno-deprecated-gpu-targets")
     endif()
     foreach(CUDA_ARCH_ELEM ${CUDA_ARCH})
         # set flags to create device code for the given architecture
-        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
-            "-Wno-deprecated-gpu-targets --generate-code arch=compute_${CUDA_ARCH_ELEM},code=sm_${CUDA_ARCH_ELEM} --generate-code arch=compute_${CUDA_ARCH_ELEM},code=compute_${CUDA_ARCH_ELEM}")
+        if("${CUDA_ARCH_ELEM}" STREQUAL "21")
+            # "2.1" actually does run faster when compiled as itself, versus in "2.0" compatible mode
+            # strange virtual code type on top of compute_20, with no compute_21 (so the normal rule fails)
+            set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
+                    "--generate-code arch=compute_20,code=sm_21")
+        else()
+            set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
+                    "--generate-code arch=compute_${CUDA_ARCH_ELEM},code=sm_${CUDA_ARCH_ELEM} --generate-code arch=compute_${CUDA_ARCH_ELEM},code=compute_${CUDA_ARCH_ELEM}")
+        endif()
     endforeach()
 
     # give each thread an independent default stream

--- a/src/Summary.cpp
+++ b/src/Summary.cpp
@@ -65,10 +65,11 @@ static void print_algo(xmrig::Config *config)
 
 static void print_gpu(xmrig::Config *config)
 {
+    constexpr size_t byteToMiB = 1024u * 1024u;
     for (const xmrig::IThread *t : config->threads()) {
-        auto thread = static_cast<const CudaThread *>(t);
-        Log::i()->text(config->isColors() ? GREEN_BOLD(" * ") WHITE_BOLD("GPU #%-8zu") YELLOW("PCI:%04x:%02x:%02x") GREEN(" %s @ %d/%d MHz") " \x1B[1;30m%dx%d %dx%d arch:%d%d SMX:%d"
-                                          : " * GPU #%-8zuPCI:%04x:%02x:%02x %s @ %d/%d MHz %dx%d %dx%d arch:%d%d SMX:%d",
+        auto thread = dynamic_cast<const CudaThread *>(t);
+        Log::i()->text(config->isColors() ? GREEN_BOLD(" * ") WHITE_BOLD("GPU #%-8zu") YELLOW("PCI:%04x:%02x:%02x") GREEN(" %s @ %d/%d MHz") " \x1B[1;30m%dx%d %dx%d arch:%d%d SMX:%d MEM:%zu/%zu MiB"
+                                          : " * GPU #%-8zuPCI:%04x:%02x:%02x %s @ %d/%d MHz %dx%d %dx%d arch:%d%d SMX:%d MEM:%zu/%zu MiB",
                        thread->index(),
                        thread->pciDomainID(),
                        thread->pciBusID(),
@@ -82,7 +83,9 @@ static void print_gpu(xmrig::Config *config)
                        thread->bsleep(),
                        thread->arch()[0],
                        thread->arch()[1],
-                       thread->smx()
+                       thread->smx(),
+                       thread->memoryFree() / byteToMiB,
+                       thread->memoryTotal() / byteToMiB
         );
     }
 }

--- a/src/nvidia/cryptonight.h
+++ b/src/nvidia/cryptonight.h
@@ -50,6 +50,8 @@ typedef struct {
     int device_bsleep;
     int device_clockRate;
     int device_memoryClockRate;
+    size_t device_memoryTotal;
+    size_t device_memoryFree;
     uint32_t device_pciBusID;
     uint32_t device_pciDeviceID;
     uint32_t device_pciDomainID;

--- a/src/workers/CudaThread.cpp
+++ b/src/workers/CudaThread.cpp
@@ -35,6 +35,8 @@ CudaThread::CudaThread() :
     m_bsleep(0),
     m_clockRate(0),
     m_memoryClockRate(0),
+    m_memoryTotal(0),
+    m_memoryFree(0),
     m_nvmlId(-1),
     m_smx(0),
     m_threads(0),
@@ -58,6 +60,8 @@ CudaThread::CudaThread(const nvid_ctx &ctx, int64_t affinity, xmrig::Algo algori
     m_bsleep(ctx.device_bsleep),
     m_clockRate(ctx.device_clockRate),
     m_memoryClockRate(ctx.device_memoryClockRate),
+    m_memoryTotal(ctx.device_memoryTotal),
+    m_memoryFree(ctx.device_memoryFree),
     m_nvmlId(-1),
     m_smx(ctx.device_mpcount),
     m_threads(ctx.device_threads),
@@ -145,6 +149,8 @@ bool CudaThread::init(xmrig::Algo algorithm)
 
     m_clockRate       = ctx.device_clockRate;
     m_memoryClockRate = ctx.device_memoryClockRate;
+    m_memoryTotal     = ctx.device_memoryTotal;
+    m_memoryFree      = ctx.device_memoryFree;
     m_pciBusID        = ctx.device_pciBusID;
     m_pciDeviceID     = ctx.device_pciDeviceID;
     m_pciDomainID     = ctx.device_pciDomainID;

--- a/src/workers/CudaThread.h
+++ b/src/workers/CudaThread.h
@@ -48,6 +48,8 @@ public:
     inline int bsleep() const             { return m_bsleep; }
     inline int clockRate() const          { return m_clockRate; }
     inline int memoryClockRate() const    { return m_memoryClockRate; }
+    inline size_t memoryTotal() const     { return m_memoryTotal; }
+    inline size_t memoryFree() const      { return m_memoryFree; }
     inline int nvmlId() const             { return m_nvmlId; }
     inline int smx() const                { return m_smx; }
     inline int threads() const            { return m_threads; }
@@ -99,6 +101,8 @@ private:
     int64_t m_affinity;
     size_t m_index;
     size_t m_threadId;
+    size_t m_memoryTotal;
+    size_t m_memoryFree;
     uint32_t m_pciBusID;
     uint32_t m_pciDeviceID;
     uint32_t m_pciDomainID;


### PR DESCRIPTION
CUDA8 would crash on init randomly but constantly

moving the memory-size-check to before the cudaGetDeviceProperties fixes it

Bonus, now the Summary line shows GPU memory sizes at startup

I have not seen another startup crash since applying this on my running branch, NVS5200M arch 21.

Also adds true 2.1 support which was at least 0.6H/s (2%) faster on CN-GPU when it's the only one included via `-DCUDA_ARCH=21` - even slightly faster on easier variants like RWZ

Moved the deprecated targets silence flag to a proper location (it had been adding it once per arch  within the loop, wrongly)