### PR TITLE
Re-fix "Repair NVRTC DLL copy phase for all CUDA versions forever" forever

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,9 +295,9 @@ target_link_libraries(${CMAKE_PROJECT_NAME} xmrig-cuda ${XMRIG_ASM_LIBRARY} ${OP
 if (WIN32)
     file(GLOB NVRTCDLL "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvrtc64*.dll")
     add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCDLL}" $<TARGET_FILE_DIR:xmrig-nvidia>)
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
 
     file(GLOB NVRTCBUILTINDLL "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvrtc-builtins64*.dll")
     add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCBUILTINDLL}" $<TARGET_FILE_DIR:xmrig-nvidia>)
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${NVRTCBUILTINDLL}" $<TARGET_FILE_DIR:${CMAKE_PROJECT_NAME}>)
 endif()


### PR DESCRIPTION
Earlier fix #253 was correct as far as its aim, but overlooked when the final target name changes away from default "xmrig-nvidia"

Such as without TLS, and the target is redubbed "xmrig-nvidia-notls", then the copy phase fails with something like "no target named xmrig-nvidia", because its name had been hardcoded previously (not my bug, was always a bug)

This fixes that by using the variable containing the actual project exe name, within the target directory generator-expression.